### PR TITLE
Update META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -7,5 +7,5 @@
     "provides" : {
         "Printing::Jdf" : "lib/Printing/Jdf.pm6"
     },
-    "source-url" : "git://github.com/carbin/p6-jdf.git"
+    "source-url" : "git://github.com/nbrown/p6-jdf.git"
 }


### PR DESCRIPTION
Hi,
it appears that you changed your GH account from 'carbin'  - it was breaking the modules list.

I have already changed the META.list so this just makes the module installable again :)